### PR TITLE
Smart unadded decks

### DIFF
--- a/functions/db/databaseTypes.ts
+++ b/functions/db/databaseTypes.ts
@@ -289,6 +289,26 @@ export interface Database {
           speak_locale: string | null
         }[]
       }
+      get_unadded_public_decks_smart: {
+        Args: {
+          user_id_param: number
+        }
+        Returns: {
+          id: number
+          created_at: string
+          name: string
+          author_id: number
+          description: string
+          is_public: boolean
+          share_id: string
+          speak_locale: string
+          speak_field: string
+          available_in: string
+          category_id: string
+          category_name: string
+          category_logo: string
+        }[]
+      }
       get_user_decks_deck_id: {
         Args: {
           usr_id: number
@@ -304,14 +324,6 @@ export interface Database {
           review_count: number
           last_reminded_date: string
           is_admin: boolean
-        }[]
-      }
-      get_users_with_review_to_notify_backup: {
-        Args: Record<PropertyKey, never>
-        Returns: {
-          user_id: number
-          review_count: number
-          last_reminded_date: string
         }[]
       }
     }

--- a/functions/db/deck/get-un-added-public-decks-db.ts
+++ b/functions/db/deck/get-un-added-public-decks-db.ts
@@ -6,8 +6,8 @@ import { decksWithCardsSchema } from "./decks-with-cards-schema.ts";
 export const getUnAddedPublicDecksDb = async (env: EnvSafe, userId: number) => {
   const db = getDatabase(env);
 
-  const { data, error } = await db.rpc("get_unadded_public_decks", {
-    user_id: userId,
+  const { data, error } = await db.rpc("get_unadded_public_decks_smart", {
+    user_id_param: userId,
   });
 
   if (error) {
@@ -15,6 +15,15 @@ export const getUnAddedPublicDecksDb = async (env: EnvSafe, userId: number) => {
   }
 
   return decksWithCardsSchema.parse(
-    data.map((item) => ({ ...item, deck_card: [] })),
+    data.map((item) => {
+      const { category_name, category_logo, ...rest } = item;
+      return {
+        ...rest,
+        deck_card: [],
+        deck_category: rest.category_id
+          ? { name: category_name, logo: category_logo }
+          : undefined,
+      };
+    }),
   );
 };

--- a/src/screens/deck-catalog/deck-added-label.tsx
+++ b/src/screens/deck-catalog/deck-added-label.tsx
@@ -5,7 +5,7 @@ import React from "react";
 export const DeckAddedLabel = () => {
   return (
     <div
-      title={'This deck is on your list'}
+      title={"This deck is on your list"}
       className={css({
         position: "absolute",
         right: 0,

--- a/src/screens/deck-list/main-screen.tsx
+++ b/src/screens/deck-list/main-screen.tsx
@@ -15,6 +15,7 @@ import { assert } from "../../lib/typescript/assert.ts";
 import { ListHeader } from "../../ui/list-header.tsx";
 import { range } from "../../lib/array/range.ts";
 import { reset } from "../../ui/reset.ts";
+import { ViewMoreDecksToggle } from "./view-more-decks-toggle.tsx";
 
 export const MainScreen = observer(() => {
   useMount(() => {
@@ -31,7 +32,14 @@ export const MainScreen = observer(() => {
       })}
     >
       <div>
-        <ListHeader text={"My decks"} />
+        <ListHeader
+          text={"My decks"}
+          rightSlot={
+            deckListStore.shouldShowMyDecksToggle ? (
+              <ViewMoreDecksToggle />
+            ) : undefined
+          }
+        />
         <div
           className={css({
             display: "flex",
@@ -44,7 +52,7 @@ export const MainScreen = observer(() => {
               <DeckLoading key={i} />
             ))}
           {deckListStore.myInfo
-            ? deckListStore.myDecks.map((deck) => {
+            ? deckListStore.myDecksVisible.map((deck) => {
                 return <MyDeck key={deck.id} deck={deck} />;
               })
             : null}
@@ -97,7 +105,7 @@ export const MainScreen = observer(() => {
         >
           {deckListStore.myInfo ? (
             <>
-              {deckListStore.publicDecksToDisplay.map((deck) => (
+              {deckListStore.publicDecks.map((deck) => (
                 <PublicDeck key={deck.id} deck={deck} />
               ))}
               <button

--- a/src/screens/deck-list/view-more-decks-toggle.tsx
+++ b/src/screens/deck-list/view-more-decks-toggle.tsx
@@ -1,0 +1,36 @@
+import { observer } from "mobx-react-lite";
+import { css, cx } from "@emotion/css";
+import { reset } from "../../ui/reset.ts";
+import { theme } from "../../ui/theme.tsx";
+import { deckListStore } from "../../store/deck-list-store.ts";
+import { ChevronIcon } from "../../ui/chevron-icon.tsx";
+import React from "react";
+
+export const ViewMoreDecksToggle = observer(() => {
+  return (
+    <button
+      className={cx(
+        reset.button,
+        css({
+          position: "absolute",
+          right: 12,
+          top: 2,
+          color: theme.linkColor,
+          fontSize: 14,
+          textTransform: "uppercase",
+          display: "flex",
+          alignItems: "center",
+          gap: 4,
+        }),
+      )}
+      onClick={deckListStore.isMyDecksExpanded.toggle}
+    >
+      <span className={css({ transform: "translateY(2px)" })}>
+        <ChevronIcon
+          direction={deckListStore.isMyDecksExpanded.value ? "top" : "bottom"}
+        />
+      </span>
+      {deckListStore.isMyDecksExpanded.value ? "Hide" : "Show all"}
+    </button>
+  );
+});

--- a/src/ui/chevron-icon.tsx
+++ b/src/ui/chevron-icon.tsx
@@ -1,0 +1,43 @@
+import { motion } from "framer-motion";
+import React, { SVGProps } from "react";
+
+type Direction = "top" | "bottom";
+
+const getRotation = (direction: Direction) => {
+  switch (direction) {
+    case "top":
+      return 0;
+    case "bottom":
+      return 180;
+  }
+};
+
+type Props = Pick<SVGProps<SVGSVGElement>, "onClick" | "className"> & {
+  direction: Direction;
+};
+
+export const ChevronIcon = (props: Props) => {
+  const { direction, ...restProps } = props;
+  return (
+    <motion.svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      whileTap={{ scale: 0.9 }}
+      animate={{ rotate: getRotation(direction) }}
+      initial={false}
+      {...restProps}
+    >
+      <path
+        d="M4 10.5L8.5 6L13 10.5"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeMiterlimit="10"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </motion.svg>
+  );
+};

--- a/src/ui/list-header.tsx
+++ b/src/ui/list-header.tsx
@@ -1,10 +1,15 @@
 import { css } from "@emotion/css";
 import { theme } from "./theme.tsx";
-import React from "react";
+import React, { ReactNode } from "react";
 
-type Props = { text: string };
+type Props = {
+  text: string;
+  rightSlot?: ReactNode;
+};
 
 export const ListHeader = (props: Props) => {
+  const { text, rightSlot } = props;
+
   return (
     <h5
       className={css({
@@ -15,11 +20,13 @@ export const ListHeader = (props: Props) => {
         paddingTop: 4,
         paddingBottom: 0,
         marginBottom: 4,
+        position: "relative",
         color: theme.hintColor,
         textTransform: "uppercase",
       })}
     >
-      {props.text}
+      {text}
+      {rightSlot}
     </h5>
   );
 };


### PR DESCRIPTION
- In the catalog preview, show 3 decks that have not yet been added, and prioritize those that match the user’s language. Otherwise, show decks in English.
- In “My Decks” section, display a maximum of 3 decks, sorted by the number of cards to repeat, and then by the number of new cards. Add a toggle button.